### PR TITLE
Fix fastlane

### DIFF
--- a/NavigationForiOSTests/NavigationForiOSTests.swift
+++ b/NavigationForiOSTests/NavigationForiOSTests.swift
@@ -22,7 +22,7 @@ class NavigationForiOSTests: XCTestCase {
     }
     
     func testExample() {
-        XCTAssertTrue(true)
+        XCTAssertTrue(false)
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }

--- a/NavigationForiOSTests/NavigationForiOSTests.swift
+++ b/NavigationForiOSTests/NavigationForiOSTests.swift
@@ -22,7 +22,7 @@ class NavigationForiOSTests: XCTestCase {
     }
     
     func testExample() {
-        XCTAssertTrue(false)
+        XCTAssertTrue(true)
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,11 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    scan
+    if is_ci?
+      scan(skip_slack: false, slack_only_on_failure)
+    else 
+      scan(skip_slack: true)
+    end
   end
 
   desc "Submit a new Beta Build to Apple TestFlight"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,9 +56,9 @@ platform :ios do
   after_all do |lane|
     # This block is called, only if the executed lane was successful
 
-    slack(
-      message: "Successfully deployed new App Update."
-    )
+    #slack(
+    #  message: "Successfully deployed new App Update."
+    #)
   end
 
   error do |lane, exception|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ platform :ios do
   desc "Runs all the tests"
   lane :test do
     if is_ci?
-      scan(skip_slack: false, slack_only_on_failure)
+      scan(skip_slack: false, slack_only_on_failure: true)
     else 
       scan(skip_slack: true)
     end


### PR DESCRIPTION
change slack message.

before, fastlane send success and failed message on executed `fastlane test` by Travis CI and local.
after, this send result message only failed, don't send message in local.