### PR TITLE
[FIX]正しく受信できてないビーコンを除外する

### DIFF
--- a/NavigationForiOS/BeaconService.swift
+++ b/NavigationForiOS/BeaconService.swift
@@ -139,10 +139,10 @@ class BeaconService: NSObject, CLLocationManagerDelegate {
             //複数あった場合は一番RSSI値の大きいビーコンを取得する
             var maxId = 0
             for i in (1 ..< beacons.count){
-                let b : CLBeacon! = beacons[i]
+                let tmpBeacon : CLBeacon! = beacons[i]
                 //使用しているUUIDのビーコン　かつ　0dBでない（ちゃんと受信できている）ビーコンであるかを判定s
-                if(UUIDList.contains(b.proximityUUID.uuidString) && b.rssi != 0){
-                    if(beacons[maxId].rssi < b.rssi){
+                if(UUIDList.contains(tmpBeacon.proximityUUID.uuidString) && tmpBeacon.rssi != 0){
+                    if(beacons[maxId].rssi < tmpBeacon.rssi){
                         maxId = i
                     }
                 }

--- a/NavigationForiOS/BeaconService.swift
+++ b/NavigationForiOS/BeaconService.swift
@@ -139,8 +139,9 @@ class BeaconService: NSObject, CLLocationManagerDelegate {
             //複数あった場合は一番RSSI値の大きいビーコンを取得する
             var maxId = 0
             for i in (1 ..< beacons.count){
-                if(UUIDList.contains(beacons[i].proximityUUID.uuidString)){
-                    if(beacons[maxId].rssi < beacons[i].rssi){
+                let b : CLBeacon! = beacons[i]
+                if(UUIDList.contains(b.proximityUUID.uuidString)){
+                    if(beacons[maxId].rssi < b.rssi){
                         maxId = i
                     }
                 }

--- a/NavigationForiOS/BeaconService.swift
+++ b/NavigationForiOS/BeaconService.swift
@@ -139,10 +139,9 @@ class BeaconService: NSObject, CLLocationManagerDelegate {
             //複数あった場合は一番RSSI値の大きいビーコンを取得する
             var maxId = 0
             for i in (1 ..< beacons.count){
-                let tmpBeacon : CLBeacon! = beacons[i]
-                //使用しているUUIDのビーコン　かつ　0dBでない（ちゃんと受信できている）ビーコンであるかを判定s
-                if(UUIDList.contains(tmpBeacon.proximityUUID.uuidString) && tmpBeacon.rssi != 0){
-                    if(beacons[maxId].rssi < tmpBeacon.rssi){
+                //使用しているUUIDのビーコン　かつ　0dBでない（ちゃんと受信できている）ビーコンであるかを判定する
+                if(UUIDList.contains(beacons[i].proximityUUID.uuidString) && beacons[i].rssi != 0){
+                    if(beacons[maxId].rssi < beacons[i].rssi){
                         maxId = i
                     }
                 }

--- a/NavigationForiOS/BeaconService.swift
+++ b/NavigationForiOS/BeaconService.swift
@@ -140,7 +140,8 @@ class BeaconService: NSObject, CLLocationManagerDelegate {
             var maxId = 0
             for i in (1 ..< beacons.count){
                 let b : CLBeacon! = beacons[i]
-                if(UUIDList.contains(b.proximityUUID.uuidString)){
+                //使用しているUUIDのビーコン　かつ　0dBでない（ちゃんと受信できている）ビーコンであるかを判定s
+                if(UUIDList.contains(b.proximityUUID.uuidString) && b.rssi != 0){
                     if(beacons[maxId].rssi < b.rssi){
                         maxId = i
                     }


### PR DESCRIPTION
問題
0dBで受信しているビーコンが、一番RSSIの大きいビーコンにされている状態が発生

修正
0dBで受信したビーコンは、対象から除外する処理を入れる
