### PR TITLE
[FIX]NavigationControllerのthresholdをナビゲーションデータのものにする

### DIFF
--- a/NavigationForiOS/NavigationController.swift
+++ b/NavigationForiOS/NavigationController.swift
@@ -48,8 +48,9 @@ class NavigationController{
         navigation_text = ""
         if(retval.flag == true){
             //ナビゲーションの更新
-            //RSSI最大のビーコンのRSSIの値が-80dB以下のとき、案内が表示されるようにする
-            if(isOnNavigationPoint(RSSI: retval.rssi, threshold: -80)){
+            //RSSI最大のビーコンの閾値を取得し、ナビゲーションポイントに到達したかを判定する
+            let threshold = navigations?.getBeaconThreshold(id: minor_id)
+            if(isOnNavigationPoint(RSSI: retval.rssi, threshold: threshold!)){
                 //ゴールに到着したかを判定
                 if(isGoal(minor_id: retval.minor)){
                     //到着した

--- a/NavigationForiOS/NavigationEntity.swift
+++ b/NavigationForiOS/NavigationEntity.swift
@@ -60,6 +60,12 @@ class NavigationEntity{
         return (retval?.navigation_text)!
     }
     
+    //指定したminorの閾値を返す
+    func getBeaconThreshold(id : Int) -> Int{
+        let retval = routes.filter({ $0.minor_id == id}).first
+        return (retval?.threshold)!
+    }
+    
     //使用するビーコンのUUIDリストを返す
     func getUUIDList() -> Array<String>{
         return UUIDList

--- a/NavigationForiOSTests/NavigationEntityTests.swift
+++ b/NavigationForiOSTests/NavigationEntityTests.swift
@@ -84,6 +84,22 @@ class NavigationEntityTests: XCTestCase {
         XCTAssertNotEqual(retval2, "Start")
     }
     
+    func testGetBeaconThreshold_成功するとき(){
+        let retval1 = navigations.getBeaconThreshold(id : 1)
+        XCTAssertEqual(retval1, -80)
+        let retval2 = navigations.getBeaconThreshold(id : 2)
+        XCTAssertEqual(retval2, -74)
+        let retval3 = navigations.getBeaconThreshold(id : 3)
+        XCTAssertEqual(retval3, -65)
+        let retval4 = navigations.getBeaconThreshold(id : 4)
+        XCTAssertEqual(retval4, -70)
+    }
+    
+    func testGetBeaconThreshold_失敗するとき(){
+        let retval1 = navigations.getBeaconThreshold(id : 1)
+        XCTAssertNotEqual(retval1, -74)
+    }
+    
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
## 対象
NavigationController.swift 内の、52行目

if(isOnNavigationPoint(RSSI: retval.rssi, threshold: -80))

## 問題
thresholdの値が、-80dBで固定となっており、ナビゲーションデータの値が反映されていない

## 対処
ナビゲーションデータのthresholdの値が入るようにする

{
    "routes":[
        {
            "minor":1,
            "threshold":-80,
            "navigation":"左折です",
            "type":1
        },
        {
            "minor":2,
            "threshold":-80,
            "navigation":"右折です",
            "type":2
        },
        {
            "minor":3,
            "threshold":-80,
            "navigation":"右折です",
            "type":1
        }
    ],
    "start":1,
    "goal":3
}