### PR TITLE
[WIP][FIX]BeaconServiceが0dBのビーコンを受信する問題

### DIFF
--- a/NavigationForiOS/BeaconService.swift
+++ b/NavigationForiOS/BeaconService.swift
@@ -140,7 +140,7 @@ class BeaconService: NSObject, CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didRangeBeacons beacons: [CLBeacon], in region: CLBeaconRegion) {
         
         //使用しているビーコンだけにフィルタリングする
-        let availableBeacons = beacons.filter({ navigations.isAvailableBeaconId(uuid: $0.proximityUUID.uuidString, minor_id: Int($0.minor))})
+        let availableBeacons = beacons.filter({ navigations.isAvailableBeaconId(uuid: $0.proximityUUID.uuidString, minor_id: Int($0.minor)) && $0.rssi != 0})
         if(availableBeacons.count > 0){
             //複数あった場合は一番RSSI値の大きいビーコンを取得する
             var maxId = 0


### PR DESCRIPTION
## 問題
- 0dBのビーコンがmaxRssiBeaconとして処理されてしまう
ISSSUE : #35

## 原因
- maxRssiBeaconを取得する際に、0dBのビーコンを除外していなかった

## 対処
143行目のフィルタリング処理を修正する