### PR TITLE
長さの予想のミスを修正

### DIFF
--- a/NavigationForiOS/NavigationStateController.swift
+++ b/NavigationForiOS/NavigationStateController.swift
@@ -71,7 +71,7 @@ class Road: NavigationState{
     /// - Parameter navigations: ナビゲーション情報
     /// - Returns: ナビゲーションテキスト
     func getNavigation(navigations: NavigationEntity) -> String {
-        let distance = Int(Double(navigations.routes[currentRouteId].expectedBeacons.count) * Const().stepLength)
+        let distance = Int(Double(navigations.routes[currentRouteId+1].expectedBeacons.count) * Const().stepLength)
         return "\(distance)メートル，直進です。"
     }
     


### PR DESCRIPTION
長さの予想の際に，次の通路の電波強度の数ではなく，今いる交差点の電波強度の数を使用していたので，修正
